### PR TITLE
go.mk: remove submodule and initialize through make

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - run: git submodule update --init --recursive go.mk
+      - run: make go.mk
       - uses: ./go.mk/.github/actions/setup
 
       - uses: ./go.mk/.github/actions/pre-check

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - run: git submodule update --init --recursive go.mk
+      - run: make go.mk
         shell: bash
 
       - name: Import GPG key

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+/go.mk
 dist/
 bin/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "go.mk"]
-	path = go.mk
-	url = https://github.com/exoscale/go.mk.git

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Improvements
 
-- 
+- go.mk: remove submodule and initialize through make #12 
 - automate release with Exoscale Tooling GPG key #11
 
 ## 0.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Improvements
 
+- 
 - automate release with Exoscale Tooling GPG key #11
 
 ## 0.2.0

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,35 @@
+GO_MK_REF := v1.0.0
+
+# make go.mk a dependency for all targets
+.EXTRA_PREREQS = go.mk
+
+ifndef MAKE_RESTARTS
+# This section will be processed the first time that make reads this file.
+
+# This causes make to re-read the Makefile and all included
+# makefiles after go.mk has been cloned.
+Makefile:
+	@touch Makefile
+endif
+
+.PHONY: go.mk
+.ONESHELL:
+go.mk:
+	@if [ ! -d "go.mk" ]; then
+		git clone https://github.com/exoscale/go.mk.git
+	fi
+	@cd go.mk
+	@if ! git show-ref --quiet --verify "refs/heads/${GO_MK_REF}"; then
+		git fetch
+	fi
+	@if ! git show-ref --quiet --verify "refs/tags/${GO_MK_REF}"; then
+		git fetch --tags
+	fi
+	git checkout --quiet ${GO_MK_REF}
+
+go.mk/init.mk:
 include go.mk/init.mk
+go.mk/public.mk:
 include go.mk/public.mk
 
 PACKAGE := github.com/exoscale/vault-plugin-auth-exoscale


### PR DESCRIPTION
# Testing
```shell
❯ make build
Cloning into 'go.mk'...
remote: Enumerating objects: 311, done.
remote: Counting objects: 100% (197/197), done.
remote: Compressing objects: 100% (96/96), done.
remote: Total 311 (delta 132), reused 137 (delta 92), pack-reused 114
Receiving objects: 100% (311/311), 62.32 KiB | 3.46 MiB/s, done.
Resolving deltas: 100% (175/175), done.
mkdir -p '/home/sauterp/src/github.com/exoscale/vault-plugin-auth-exoscale/bin'
'/home/sauterp/bin/go' build \
   \
  -ldflags "-s -w -X github.com/exoscale/vault-plugin-auth-exoscale/version.Version=dev -X github.com/exoscale/vault-plugin-auth-exoscale/version.Commit=6bbe2e2" \
   \
  -o '/home/sauterp/src/github.com/exoscale/vault-plugin-auth-exoscale/bin/' \
  './cmd/vault-plugin-auth-exoscale'
```