### PR TITLE
go.mk: lint with staticcheck

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - go.mk: remove submodule and initialize through make #12 
 - automate release with Exoscale Tooling GPG key #11
+- go.mk: lint with staticcheck #13 
 
 ## 0.2.0
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-GO_MK_REF := v1.0.0
+GO_MK_REF := v2.0.0
 
 # make go.mk a dependency for all targets
 .EXTRA_PREREQS = go.mk


### PR DESCRIPTION
## Testing
```shell
make lint
remote: Enumerating objects: 22, done.        
remote: Counting objects: 100% (19/19), done.        
remote: Compressing objects: 100% (11/11), done.        
remote: Total 22 (delta 8), reused 13 (delta 7), pack-reused 3        
Unpacking objects: 100% (22/22), 9.29 KiB | 1.55 MiB/s, done.
From github.com:exoscale/go.mk
   314a757..c320e5b  master     -> origin/master
 * [new tag]         v2.0.0     -> v2.0.0
 * [new tag]         v1.0.1     -> v1.0.1
'/home/sauterp/bin/go' install honnef.co/go/tools/cmd/staticcheck@2023.1.7
'/home/sauterp/go/bin/staticcheck' \
   \
  ./...
```